### PR TITLE
feat: #1 프로젝트 초기 설정 - Spring Cloud Gateway 보일러플레이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs
+hs_err_pid*
+replay_pid*
+
+# Gradle
+.gradle/
+build/
+!gradle/wrapper/gradle-wrapper.jar
+
+# IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+.vscode/
+.settings/
+.classpath
+.project
+.factorypath
+out/
+bin/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+*.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Build
+FROM gradle:8.12-jdk21 AS builder
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+
+# Download dependencies (cached layer)
+RUN gradle dependencies --no-daemon || true
+
+COPY src ./src
+
+RUN gradle bootJar --no-daemon -x test
+
+# Stage 2: Runtime
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+RUN chown appuser:appuser app.jar
+USER appuser
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.10'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.opentraum'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+ext {
+    set('springCloudVersion', '2025.0.0')
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+dependencies {
+    // Spring Cloud Gateway (reactive, WebFlux-based)
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+
+    // Actuator + Prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'opentraum-gateway'

--- a/src/main/java/com/opentraum/gateway/GatewayApplication.java
+++ b/src/main/java/com/opentraum/gateway/GatewayApplication.java
@@ -1,0 +1,12 @@
+package com.opentraum.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
+}

--- a/src/main/java/com/opentraum/gateway/config/CorsConfig.java
+++ b/src/main/java/com/opentraum/gateway/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package com.opentraum.gateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsWebFilter corsWebFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization", "X-Tenant-Id"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsWebFilter(source);
+    }
+}

--- a/src/main/java/com/opentraum/gateway/config/RouteConfig.java
+++ b/src/main/java/com/opentraum/gateway/config/RouteConfig.java
@@ -1,0 +1,57 @@
+package com.opentraum.gateway.config;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RouteConfig {
+
+    @Bean
+    public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
+        return builder.routes()
+
+                // Auth Service
+                .route("auth-service", r -> r
+                        .path("/api/v1/auth/**")
+                        .filters(f -> f
+                                .stripPrefix(1)
+                                .addRequestHeader("X-Gateway-Routed", "true"))
+                        .uri("http://auth-service:8081"))
+
+                // User Service
+                .route("user-service", r -> r
+                        .path("/api/v1/users/**")
+                        .filters(f -> f
+                                .stripPrefix(1)
+                                .addRequestHeader("X-Gateway-Routed", "true"))
+                        .uri("http://user-service:8082"))
+
+                // Event Service
+                .route("event-service", r -> r
+                        .path("/api/v1/events/**")
+                        .filters(f -> f
+                                .stripPrefix(1)
+                                .addRequestHeader("X-Gateway-Routed", "true"))
+                        .uri("http://event-service:8083"))
+
+                // Reservation Service
+                .route("reservation-service", r -> r
+                        .path("/api/v1/reservations/**")
+                        .filters(f -> f
+                                .stripPrefix(1)
+                                .addRequestHeader("X-Gateway-Routed", "true"))
+                        .uri("http://reservation-service:8084"))
+
+                // Payment Service
+                .route("payment-service", r -> r
+                        .path("/api/v1/payments/**")
+                        .filters(f -> f
+                                .stripPrefix(1)
+                                .addRequestHeader("X-Gateway-Routed", "true"))
+                        .uri("http://payment-service:8085"))
+
+                .build();
+    }
+}

--- a/src/main/java/com/opentraum/gateway/filter/TenantResolverFilter.java
+++ b/src/main/java/com/opentraum/gateway/filter/TenantResolverFilter.java
@@ -1,0 +1,97 @@
+package com.opentraum.gateway.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Global filter that resolves the tenant ID for multi-tenancy support.
+ *
+ * Tenant resolution strategy (priority order):
+ * 1. X-Tenant-Id request header
+ * 2. Subdomain extraction (e.g., tenant1.opentraum.com -> tenant1)
+ */
+@Component
+public class TenantResolverFilter implements GlobalFilter, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantResolverFilter.class);
+
+    private static final String TENANT_HEADER = "X-Tenant-Id";
+    private static final String DEFAULT_TENANT = "default";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+
+        String tenantId = resolveTenantId(request);
+
+        if (tenantId == null || tenantId.isBlank()) {
+            log.warn("Tenant ID could not be resolved for request: {}", request.getURI());
+            exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+            return exchange.getResponse().setComplete();
+        }
+
+        log.debug("Resolved tenant ID: {} for request: {}", tenantId, request.getURI().getPath());
+
+        ServerHttpRequest mutatedRequest = request.mutate()
+                .header(TENANT_HEADER, tenantId)
+                .build();
+
+        return chain.filter(exchange.mutate().request(mutatedRequest).build());
+    }
+
+    private String resolveTenantId(ServerHttpRequest request) {
+        // 1. Check X-Tenant-Id header
+        String headerTenant = request.getHeaders().getFirst(TENANT_HEADER);
+        if (headerTenant != null && !headerTenant.isBlank()) {
+            return headerTenant.trim();
+        }
+
+        // 2. Extract from subdomain
+        String host = request.getHeaders().getFirst("Host");
+        if (host != null) {
+            String subdomain = extractSubdomain(host);
+            if (subdomain != null) {
+                return subdomain;
+            }
+        }
+
+        // 3. Fallback to default tenant
+        return DEFAULT_TENANT;
+    }
+
+    private String extractSubdomain(String host) {
+        // Remove port if present
+        String hostname = host.contains(":") ? host.substring(0, host.indexOf(':')) : host;
+
+        // Skip localhost and IP addresses
+        if (hostname.equals("localhost") || hostname.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
+            return null;
+        }
+
+        String[] parts = hostname.split("\\.");
+        // At least 3 parts needed (subdomain.domain.tld)
+        if (parts.length >= 3) {
+            String subdomain = parts[0];
+            // Skip common non-tenant subdomains
+            if (!subdomain.equals("www") && !subdomain.equals("api")) {
+                return subdomain;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public int getOrder() {
+        // Run early in the filter chain to ensure tenant is available for downstream filters
+        return Ordered.HIGHEST_PRECEDENCE + 10;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,144 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: opentraum-gateway
+
+  cloud:
+    gateway:
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials, RETAIN_UNIQUE
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOriginPatterns: "*"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
+
+# Actuator & Prometheus
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus, gateway
+  endpoint:
+    health:
+      show-details: when-authorized
+    gateway:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+# Logging
+logging:
+  level:
+    root: INFO
+    com.opentraum.gateway: DEBUG
+    org.springframework.cloud.gateway: DEBUG
+
+---
+# Dev Profile
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: http://localhost:8081
+          predicates:
+            - Path=/api/v1/auth/**
+          filters:
+            - StripPrefix=1
+        - id: user-service
+          uri: http://localhost:8082
+          predicates:
+            - Path=/api/v1/users/**
+          filters:
+            - StripPrefix=1
+        - id: event-service
+          uri: http://localhost:8083
+          predicates:
+            - Path=/api/v1/events/**
+          filters:
+            - StripPrefix=1
+        - id: reservation-service
+          uri: http://localhost:8084
+          predicates:
+            - Path=/api/v1/reservations/**
+          filters:
+            - StripPrefix=1
+        - id: payment-service
+          uri: http://localhost:8085
+          predicates:
+            - Path=/api/v1/payments/**
+          filters:
+            - StripPrefix=1
+
+logging:
+  level:
+    root: DEBUG
+    com.opentraum.gateway: TRACE
+
+---
+# Prod Profile
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  cloud:
+    gateway:
+      routes:
+        - id: auth-service
+          uri: http://auth-service:8081
+          predicates:
+            - Path=/api/v1/auth/**
+          filters:
+            - StripPrefix=1
+        - id: user-service
+          uri: http://user-service:8082
+          predicates:
+            - Path=/api/v1/users/**
+          filters:
+            - StripPrefix=1
+        - id: event-service
+          uri: http://event-service:8083
+          predicates:
+            - Path=/api/v1/events/**
+          filters:
+            - StripPrefix=1
+        - id: reservation-service
+          uri: http://reservation-service:8084
+          predicates:
+            - Path=/api/v1/reservations/**
+          filters:
+            - StripPrefix=1
+        - id: payment-service
+          uri: http://payment-service:8085
+          predicates:
+            - Path=/api/v1/payments/**
+          filters:
+            - StripPrefix=1
+
+logging:
+  level:
+    root: WARN
+    com.opentraum.gateway: INFO
+
+management:
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## Summary

OpenTraum 멀티 테넌시 B2B2C 티켓팅 플랫폼의 **API Gateway 보일러플레이트**를 구성합니다.

Spring Cloud Gateway 기반의 리액티브 게이트웨이로, MSA 아키텍처에서 모든 클라이언트 요청의 **단일 진입점(Single Entry Point)** 역할을 담당합니다. 멀티 테넌시 지원을 위한 Tenant Resolver 필터와 5개 다운스트림 서비스로의 라우팅 설정, 모니터링을 위한 Actuator/Prometheus 통합을 포함합니다.

## Changes

### 빌드 설정
- `build.gradle` — Spring Cloud Gateway, Actuator, Micrometer Prometheus 의존성 구성 (Spring Boot 3.5.10, Spring Cloud 2025.0.0)
- `settings.gradle` — rootProject.name 설정
- `gradle/wrapper/gradle-wrapper.properties` — Gradle 8.12 래퍼 설정

### 애플리케이션
- `GatewayApplication.java` — Spring Boot 메인 엔트리포인트

### 라우트 설정 (RouteConfig.java)
- Java DSL 기반 라우트 정의
- 5개 다운스트림 서비스 라우팅:
  - Auth Service (`/api/v1/auth/**` → `:8081`)
  - User Service (`/api/v1/users/**` → `:8082`)
  - Event Service (`/api/v1/events/**` → `:8083`)
  - Reservation Service (`/api/v1/reservations/**` → `:8084`)
  - Payment Service (`/api/v1/payments/**` → `:8085`)
- `StripPrefix=1` 필터 및 `X-Gateway-Routed` 헤더 추가

### CORS 설정 (CorsConfig.java)
- `CorsWebFilter` 기반 글로벌 CORS 설정
- 모든 origin 패턴 허용 (개발 단계)
- `Authorization`, `X-Tenant-Id` 헤더 노출
- Credentials 허용, Max-Age 3600초

### 멀티 테넌시 필터 (TenantResolverFilter.java)
- `GlobalFilter` 구현으로 모든 요청에 대해 테넌트 ID 해석
- 우선순위별 테넌트 해석 전략:
  1. `X-Tenant-Id` 요청 헤더
  2. 서브도메인 추출 (e.g., `tenant1.opentraum.com` → `tenant1`)
  3. 기본 테넌트(`default`) 폴백
- `www`, `api` 등 비테넌트 서브도메인 필터링
- localhost/IP 주소 스킵 처리

### 애플리케이션 설정 (application.yml)
- 프로파일별 설정 분리 (default / dev / prod)
- **dev 프로파일**: `localhost` 기반 라우팅 (로컬 개발용)
- **prod 프로파일**: K8s 서비스 이름 기반 라우팅 (`http://auth-service:8081` 등)
- Actuator 엔드포인트: `health`, `info`, `metrics`, `prometheus`, `gateway`
- 프로파일별 로깅 레벨 차등 적용

### 인프라
- `Dockerfile` — 멀티 스테이지 빌드 (gradle:8.12-jdk21 → eclipse-temurin:21-jre-jammy)
  - 의존성 캐싱 레이어 최적화
  - 비root 사용자(`appuser`) 실행
  - 포트 8080 노출
- `.gitignore` — Java/Gradle/IDE/OS 표준 ignore 규칙

## Test Plan

- [ ] `./gradlew bootRun --args='--spring.profiles.active=dev'`로 로컬 기동 확인
- [ ] `http://localhost:8080/actuator/health` 헬스체크 응답 확인
- [ ] `http://localhost:8080/actuator/prometheus` 메트릭 엔드포인트 확인
- [ ] `http://localhost:8080/actuator/gateway/routes` 라우트 목록 확인
- [ ] `X-Tenant-Id` 헤더 포함 요청 시 다운스트림으로 테넌트 ID 전파 확인
- [ ] CORS preflight (OPTIONS) 요청 정상 응답 확인
- [ ] `docker build -t opentraum-gateway .` 빌드 성공 확인
- [ ] Docker 컨테이너 기동 후 Actuator 응답 확인

closes #1
