### PR TITLE
feat: #7 JWT tenantId → X-Tenant-Id 헤더 전파

### DIFF
--- a/src/main/java/com/opentraum/gateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/opentraum/gateway/filter/JwtAuthenticationFilter.java
@@ -107,6 +107,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     private Mono<Void> injectUserHeaders(ServerWebExchange exchange, GatewayFilterChain chain, String token) {
         Long userId = jwtProvider.getUserId(token);
         String role = jwtProvider.getRole(token);
+        String tenantId = jwtProvider.getTenantId(token);
         String path = exchange.getRequest().getURI().getPath();
 
         // admin 경로 역할 검증
@@ -116,12 +117,17 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             return exchange.getResponse().setComplete();
         }
 
-        ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+        var requestBuilder = exchange.getRequest().mutate()
                 .header("X-User-Id", userId.toString())
-                .header("X-User-Role", role != null ? role : "CONSUMER")
-                .build();
+                .header("X-User-Role", role != null ? role : "CONSUMER");
 
-        log.debug("JWT 인증 완료: userId={}, role={}, path={}", userId, role, path);
+        if (tenantId != null) {
+            requestBuilder.header("X-Tenant-Id", tenantId);
+        }
+
+        ServerHttpRequest mutatedRequest = requestBuilder.build();
+
+        log.debug("JWT 인증 완료: userId={}, role={}, tenantId={}, path={}", userId, role, tenantId, path);
 
         return chain.filter(exchange.mutate().request(mutatedRequest).build());
     }

--- a/src/main/java/com/opentraum/gateway/util/JwtProvider.java
+++ b/src/main/java/com/opentraum/gateway/util/JwtProvider.java
@@ -57,4 +57,8 @@ public class JwtProvider {
     public String getRole(String token) {
         return getClaims(token).get("role", String.class);
     }
+
+    public String getTenantId(String token) {
+        return getClaims(token).get("tenantId", String.class);
+    }
 }


### PR DESCRIPTION
## 개요
인증된 사용자의 JWT에서 tenantId를 추출하여 X-Tenant-Id 헤더로 다운스트림에 전파한다.

closes #7

## 변경 사항
| 파일 | 변경 |
|---|---|
| `JwtProvider.java` | getTenantId() 추가 |
| `JwtAuthenticationFilter.java` | JWT tenantId → X-Tenant-Id 헤더 설정 |

## 컴파일 검증
- `./gradlew compileJava` ✅ BUILD SUCCESSFUL