### PR TITLE
feat: k8s 매니페스트 운영 설정 반영 및 develop PR 게이트 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Validation
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test:

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -10,6 +10,11 @@ metadata:
 spec:
   revisionHistoryLimit: 2
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: gateway
@@ -20,12 +25,20 @@ spec:
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: gateway
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 40
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: gateway
       imagePullSecrets:
         - name: harbor-secret
       containers:
         - name: gateway
           image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-gateway:80c3c96da9cd683c47a1d72436cdc8ec11b1478e
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -36,7 +49,7 @@ spec:
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
-              value: "true"
+              value: "false"
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
Closes #16

## 변경 사항

### `k8s/deployment.yml`
- `spec.strategy` 추가 - `RollingUpdate` + `maxSurge: 1`, `maxUnavailable: 0`
- `spec.template.spec.terminationGracePeriodSeconds: 40`
- `spec.template.spec.topologySpreadConstraints` 추가 - `maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`
- `containers[0].imagePullPolicy: Always`
- `env.SPRING_MAIN_LAZY_INITIALIZATION` `"true"` -> `"false"`

### `.github/workflows/build.yml`
- `on.pull_request.branches`: `[main]` -> `[main, develop]`

## 검증 항목

- [ ] feat/#16 -> develop PR 생성 시 `Build Validation` 워크플로 트리거 확인
- [ ] develop -> main 동기화 PR 머지 후 `CI/CD (main)` 정상 트리거
- [ ] ArgoCD `opentraum-gateway` 자동 sync 후 `Synced + Healthy`
- [ ] gateway Pod replicas 2개가 다른 노드에 스케줄
- [ ] 새 Pod env `SPRING_MAIN_LAZY_INITIALIZATION=false` 확인
