### PR TITLE
feat: k8s 매니페스트 운영 설정 마무리 반영

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: opentraum
   labels:
     app: gateway
+    app.kubernetes.io/name: gateway
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: gateway
 spec:
@@ -22,10 +23,12 @@ spec:
     metadata:
       labels:
         app: gateway
+        app.kubernetes.io/name: gateway
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: gateway
     spec:
       terminationGracePeriodSeconds: 40
+      priorityClassName: opentraum-high
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -37,7 +40,7 @@ spec:
         - name: harbor-secret
       containers:
         - name: gateway
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-gateway:80c3c96da9cd683c47a1d72436cdc8ec11b1478e
+          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-gateway:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary
- `spec.template.spec.priorityClassName: opentraum-high` 추가
- 라벨 `app.kubernetes.io/name: gateway` 추가
- image tag SHA → `latest`

## Why
PR #17 에서 1차 이관(RollingUpdate, topologySpread, grace 40, lazy-init=false)했으나, OpenTraum-Infra `k8s-manual/gateway/` 의 priorityClass 와 name 라벨이 누락되어 마저 반영합니다. image tag 도 `latest` + `imagePullPolicy: Always` 패턴으로 다른 서비스와 통일합니다.

## Test plan
- [ ] ArgoCD sync 정상 확인
- [ ] gateway Pod 가 `opentraum-high` priority 로 스케줄되는지 확인
- [ ] gateway Pod replicas 2개 다른 노드 스케줄 확인
