### PR TITLE
feat: #20 Harbor → ECR 마이그레이션

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: write
 
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REGISTRY: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: skala3-cloud1-team8-opentraum-gateway
+
 jobs:
   build_image:
 
@@ -18,18 +23,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: QEMU 설정
-        uses: docker/setup-qemu-action@v3
+      - name: AWS 자격증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Amazon ECR 로그인
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker Buildx 설정
         uses: docker/setup-buildx-action@v3
-
-      - name: Harbor 로그인
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.HARBOR_REGISTRY }}
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Docker 이미지 빌드 및 푸시
         uses: docker/build-push-action@v5
@@ -37,8 +42,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ secrets.HARBOR_REGISTRY }}/skala26a-cloud/opentraum-gateway:${{ github.sha }}
+          platforms: linux/amd64
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -46,6 +51,9 @@ jobs:
 
     needs: build_image
     runs-on: ubuntu-latest
+    env:
+      ECR_REGISTRY: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com
+      ECR_REPOSITORY: skala3-cloud1-team8-opentraum-gateway
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
@@ -60,7 +68,7 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/OpenTraum/OpenTraum-gateway.git
           git fetch origin main
           git checkout main
-          sed -i "s|image: .*opentraum-gateway.*|image: ${{ secrets.HARBOR_REGISTRY }}/skala26a-cloud/opentraum-gateway:${{ github.sha }}|" k8s/deployment.yml
+          sed -i "s|image: .*opentraum-gateway.*|image: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}|" k8s/deployment.yml
           git add k8s/deployment.yml
           if git diff --cached --quiet; then
             exit 0

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -36,11 +36,9 @@ spec:
           labelSelector:
             matchLabels:
               app: gateway
-      imagePullSecrets:
-        - name: harbor-secret
       containers:
         - name: gateway
-          image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-gateway:3ce80551cc108306977177179ed65cb66c34ea50
+          image: 881490135253.dkr.ecr.ap-northeast-2.amazonaws.com/skala3-cloud1-team8-opentraum-gateway:3ce80551cc108306977177179ed65cb66c34ea50
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Closes #20

## 변경 사항
- `.github/workflows/cicd.yml`: Harbor → ECR
  - `docker/login-action` (Harbor) 제거
  - `aws-actions/configure-aws-credentials@v4` + `aws-actions/amazon-ecr-login@v2` 추가
  - 빌드 플랫폼 `linux/amd64,linux/arm64` → `linux/amd64`
  - 이미지 태그: `\${ECR_REGISTRY}/\${ECR_REPOSITORY}:\${SHA}` (env로 분리)
  - update_manifest sed 패턴도 ECR로 교체
- `k8s/deployment.yml`:
  - `imagePullSecrets: harbor-secret` 줄 삭제
  - 이미지 URI: `881490135253.dkr.ecr.ap-northeast-2.amazonaws.com/skala3-cloud1-team8-opentraum-gateway:SHA`

## 사전 조건 (머지 전)
- [ ] 레포 secrets에 `AWS_ACCESS_KEY_ID` 등록
- [ ] 레포 secrets에 `AWS_SECRET_ACCESS_KEY` 등록

## 머지 후 동작
1. main push → cicd.yml 트리거
2. AWS 자격증명으로 ECR 로그인 → 이미지 빌드+push
3. update_manifest 잡이 `k8s/deployment.yml`에 새 SHA로 sed → main 자동 commit
4. (ArgoCD 활성 시) 자동 sync → Pod 새 이미지로 재배포

## 인증/보안
- 노드 IAM `AmazonEC2ContainerRegistryPullOnly` 활용 → Pod imagePullSecrets 불필요
- HARBOR_REGISTRY/USERNAME/PASSWORD secrets 미사용 (정리는 8개 마이그 완료 후 일괄)